### PR TITLE
Added fixes for Python3.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,11 @@ from collections import defaultdict
 
 from setuptools import Extension, find_packages, setup  # type: ignore
 from setuptools.command.build_ext import build_ext  # type: ignore
+from packaging.version import Version
 
 try:
     from Cython.Build import cythonize  # type: ignore
     from Cython.Compiler.Version import version as cython_version
-    from packaging.version import Version
 
     has_cython = True
 except ImportError:
@@ -65,7 +65,7 @@ compiler_directives = {
 }
 
 
-if Version(cython_version) >= Version("3.1.0a0"):
+if has_cython and Version(cython_version) >= Version("3.1.0a0"):
     compiler_directives["freethreading_compatible"] = True
 
 setup(


### PR DESCRIPTION
Fixes #5 

Issue with imports in setup.py was preventing the successful installation in Python3.13.

This commit fixes that issue

## Summary by Sourcery

Fix installation failures on Python 3.13 by adjusting setup.py import and version checks

Bug Fixes:
- Import Version from packaging before use to avoid missing import errors
- Add has_cython guard to the cython version comparison to prevent undefined variable reference